### PR TITLE
feat: add email sync configuration

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -47,6 +47,22 @@ The setup script installs dependencies, prepares Milvus, and initializes the loc
 - Visit [Usage Guide](usage.md) to interact with the application.
 - The `knowledgebase.db` SQLite database is created on first run to store URL and future email metadata.
 
+## Email ingestion configuration
+
+The application can optionally synchronise an IMAP inbox. Define the following environment variables in your `.env` file to enable and configure this behaviour:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `EMAIL_ENABLED` | `false` | Enable periodic email sync |
+| `IMAP_HOST` | _(empty)_ | IMAP server hostname |
+| `IMAP_PORT` | `993` | IMAP server port |
+| `IMAP_USERNAME` | _(empty)_ | IMAP account username |
+| `IMAP_PASSWORD` | _(empty)_ | IMAP account password |
+| `IMAP_MAILBOX` | `INBOX` | Mailbox to read from |
+| `IMAP_BATCH_LIMIT` | `50` | Maximum messages fetched per cycle |
+| `IMAP_USE_SSL` | `true` | Use SSL/TLS for IMAP connection |
+| `EMAIL_SYNC_INTERVAL_SECONDS` | `300` | Interval between sync cycles |
+
 ## TODOs
 
 - [ ] Provide Docker Compose configuration for full-stack deployment.

--- a/ingestion/email/__init__.py
+++ b/ingestion/email/__init__.py
@@ -1,5 +1,6 @@
-"""Email ingestion connectors."""
+"""Email ingestion connectors and orchestration utilities."""
 
 from .connector import EmailConnector, IMAPConnector
+from .orchestrator import EmailOrchestrator
 
-__all__ = ["EmailConnector", "IMAPConnector"]
+__all__ = ["EmailConnector", "IMAPConnector", "EmailOrchestrator"]

--- a/ingestion/email/orchestrator.py
+++ b/ingestion/email/orchestrator.py
@@ -1,0 +1,52 @@
+import threading
+import time
+import logging
+from typing import Optional
+
+from .connector import IMAPConnector
+
+logger = logging.getLogger(__name__)
+
+
+class EmailOrchestrator:
+    """Periodically sync emails from an IMAP source using configuration."""
+
+    def __init__(self, config):
+        self.config = config
+        self._thread: Optional[threading.Thread] = None
+        self._stop_event = threading.Event()
+
+    def start(self) -> None:
+        """Start the background email sync loop if enabled."""
+        if not self.config.EMAIL_ENABLED:
+            logger.info("Email ingestion disabled; orchestrator not started")
+            return
+        if self._thread and self._thread.is_alive():
+            return
+        self._thread = threading.Thread(target=self._run_loop, name="email-sync", daemon=True)
+        self._thread.start()
+        logger.info("Email orchestrator started")
+
+    def _run_loop(self) -> None:
+        """Background loop that fetches emails at the configured interval."""
+        connector = IMAPConnector(
+            host=self.config.IMAP_HOST,
+            username=self.config.IMAP_USERNAME,
+            password=self.config.IMAP_PASSWORD,
+            mailbox=self.config.IMAP_MAILBOX,
+            batch_limit=self.config.IMAP_BATCH_LIMIT,
+            use_ssl=self.config.IMAP_USE_SSL,
+        )
+        interval = max(1, int(self.config.EMAIL_SYNC_INTERVAL_SECONDS))
+        while not self._stop_event.is_set():
+            try:
+                connector.fetch_emails()
+            except Exception as exc:  # pragma: no cover - defensive
+                logger.error(f"Email sync error: {exc}")
+            self._stop_event.wait(interval)
+
+    def stop(self) -> None:
+        """Stop the background sync loop."""
+        self._stop_event.set()
+        if self._thread and self._thread.is_alive():
+            self._thread.join()


### PR DESCRIPTION
## Summary
- add IMAP/email sync settings to `Config`
- document email environment variables in installation guide
- start email orchestrator using configuration values

## Testing
- `python -m py_compile app.py ingestion/email/orchestrator.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a11261d01883218335022abd52cbe9