### PR TITLE
feat: add email account management UI

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -461,8 +461,210 @@
                                     <p>No URLs added yet. Add your first URL above.</p>
                                 </div>
                             {% endif %}
-                        </div>
+        </div>
+        </div>
+        </div>
+        </div>
+        </div>
+
+        <!-- Email Accounts -->
+        <div id="email-accounts" class="row mb-4">
+            <div class="col-md-12">
+                <div class="card">
+                    <div class="card-header d-flex justify-content-between align-items-center">
+                        <h5 class="mb-0"><i class="fas fa-envelope me-2"></i>Email Accounts</h5>
+                        <button class="btn btn-primary btn-sm" data-bs-toggle="modal" data-bs-target="#addEmailAccountModal">
+                            <i class="fas fa-plus me-1"></i>Add
+                        </button>
                     </div>
+                    <div class="card-body">
+                        {% if email_accounts %}
+                            <div class="table-responsive">
+                                <table class="table table-hover table-sm align-middle mb-0">
+                                    <thead class="table-light">
+                                        <tr>
+                                            <th>Display Name</th>
+                                            <th>Server</th>
+                                            <th>Username</th>
+                                            <th class="text-end">Actions</th>
+                                        </tr>
+                                    </thead>
+                                    <tbody>
+                                    {% for acct in email_accounts %}
+                                        <tr>
+                                            <td>{{ acct.account_name }}</td>
+                                            <td>{{ acct.server }}:{{ acct.port }}</td>
+                                            <td>{{ acct.username }}</td>
+                                            <td class="text-end">
+                                                <div class="btn-group btn-group-sm" role="group">
+                                                    <button type="button" class="btn btn-outline-secondary edit-account-btn"
+                                                            data-bs-toggle="modal" data-bs-target="#editEmailAccountModal"
+                                                            data-action="{{ url_for('update_email_account', account_id=acct.id) }}"
+                                                            data-id="{{ acct.id }}"
+                                                            data-name="{{ acct.account_name }}"
+                                                            data-server="{{ acct.server }}"
+                                                            data-username="{{ acct.username }}"
+                                                            data-password="{{ acct.password }}"
+                                                            data-port="{{ acct.port }}"
+                                                            data-mailbox="{{ acct.mailbox or '' }}"
+                                                            data-batch="{{ acct.batch_limit or '' }}"
+                                                            data-ssl="{{ '1' if acct.use_ssl else '0' }}">
+                                                        <i class="fas fa-pen"></i>
+                                                    </button>
+                                                    <button type="button" class="btn btn-outline-danger delete-account-btn"
+                                                            data-bs-toggle="modal" data-bs-target="#deleteEmailAccountModal"
+                                                            data-action="{{ url_for('delete_email_account', account_id=acct.id) }}"
+                                                            data-name="{{ acct.account_name }}">
+                                                        <i class="fas fa-trash"></i>
+                                                    </button>
+                                                </div>
+                                            </td>
+                                        </tr>
+                                    {% endfor %}
+                                    </tbody>
+                                </table>
+                            </div>
+                        {% else %}
+                            <div class="text-center text-muted py-4">
+                                <i class="fas fa-envelope-open fa-3x mb-3"></i>
+                                <p>No email accounts configured.</p>
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Add Email Account Modal -->
+        <div class="modal fade" id="addEmailAccountModal" tabindex="-1" aria-labelledby="addEmailAccountLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <form method="POST" action="{{ url_for('add_email_account') }}">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="addEmailAccountLabel">Add Email Account</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <div class="mb-3">
+                                <label class="form-label">Display Name</label>
+                                <input type="text" class="form-control" name="account_name" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Server</label>
+                                <input type="text" class="form-control" name="server" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Username</label>
+                                <input type="text" class="form-control" name="username" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Password</label>
+                                <input type="password" class="form-control" name="password" required>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label class="form-label">Port</label>
+                                    <input type="number" class="form-control" name="port" required>
+                                </div>
+                                <div class="col-md-6 mb-3">
+                                    <label class="form-label">Mailbox</label>
+                                    <input type="text" class="form-control" name="mailbox">
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label class="form-label">Batch Limit</label>
+                                    <input type="number" class="form-control" name="batch_limit">
+                                </div>
+                                <div class="col-md-6 mb-3 form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" name="use_ssl" id="addUseSSL">
+                                    <label class="form-check-label" for="addUseSSL">Use SSL</label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn btn-primary">Save</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Edit Email Account Modal -->
+        <div class="modal fade" id="editEmailAccountModal" tabindex="-1" aria-labelledby="editEmailAccountLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <form method="POST" id="editEmailAccountForm">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="editEmailAccountLabel">Edit Email Account</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <input type="hidden" name="account_id" id="editAccountId">
+                            <div class="mb-3">
+                                <label class="form-label">Display Name</label>
+                                <input type="text" class="form-control" name="account_name" id="editAccountName" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Server</label>
+                                <input type="text" class="form-control" name="server" id="editServer" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Username</label>
+                                <input type="text" class="form-control" name="username" id="editUsername" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Password</label>
+                                <input type="password" class="form-control" name="password" id="editPassword" required>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label class="form-label">Port</label>
+                                    <input type="number" class="form-control" name="port" id="editPort" required>
+                                </div>
+                                <div class="col-md-6 mb-3">
+                                    <label class="form-label">Mailbox</label>
+                                    <input type="text" class="form-control" name="mailbox" id="editMailbox">
+                                </div>
+                            </div>
+                            <div class="row">
+                                <div class="col-md-6 mb-3">
+                                    <label class="form-label">Batch Limit</label>
+                                    <input type="number" class="form-control" name="batch_limit" id="editBatchLimit">
+                                </div>
+                                <div class="col-md-6 mb-3 form-check form-switch">
+                                    <input class="form-check-input" type="checkbox" name="use_ssl" id="editUseSSL">
+                                    <label class="form-check-label" for="editUseSSL">Use SSL</label>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn btn-primary">Save changes</button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+
+        <!-- Delete Email Account Modal -->
+        <div class="modal fade" id="deleteEmailAccountModal" tabindex="-1" aria-labelledby="deleteEmailAccountLabel" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered">
+                <div class="modal-content">
+                    <form method="POST" id="deleteEmailAccountForm">
+                        <div class="modal-header">
+                            <h5 class="modal-title" id="deleteEmailAccountLabel">Delete Email Account</h5>
+                            <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                        </div>
+                        <div class="modal-body">
+                            <p>Are you sure you want to delete <strong id="deleteAccountName"></strong>?</p>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Cancel</button>
+                            <button type="submit" class="btn btn-danger">Delete</button>
+                        </div>
+                    </form>
                 </div>
             </div>
         </div>
@@ -764,6 +966,32 @@
                 });
             }
             setInterval(pollUploadedDeletion, 1200);
+        </script>
+        <script>
+            // Populate edit email account modal with existing data
+            document.querySelectorAll('.edit-account-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const form = document.getElementById('editEmailAccountForm');
+                    form.action = btn.dataset.action;
+                    document.getElementById('editAccountId').value = btn.dataset.id || '';
+                    document.getElementById('editAccountName').value = btn.dataset.name || '';
+                    document.getElementById('editServer').value = btn.dataset.server || '';
+                    document.getElementById('editUsername').value = btn.dataset.username || '';
+                    document.getElementById('editPassword').value = btn.dataset.password || '';
+                    document.getElementById('editPort').value = btn.dataset.port || '';
+                    document.getElementById('editMailbox').value = btn.dataset.mailbox || '';
+                    document.getElementById('editBatchLimit').value = btn.dataset.batch || '';
+                    document.getElementById('editUseSSL').checked = btn.dataset.ssl === '1';
+                });
+            });
+            // Populate delete confirmation modal
+            document.querySelectorAll('.delete-account-btn').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const form = document.getElementById('deleteEmailAccountForm');
+                    form.action = btn.dataset.action;
+                    document.getElementById('deleteAccountName').textContent = btn.dataset.name || '';
+                });
+            });
         </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add Email Accounts card with list and actions on index page
- wire Add, Edit, and Delete modals for account management
- include helper script to populate modal fields

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a127a78e288321bf8560824b75d538