### PR TITLE
Add email account and ingestion tests

### DIFF
--- a/tests/test_email_ingestion.py
+++ b/tests/test_email_ingestion.py
@@ -35,6 +35,7 @@ sys.modules.setdefault("langchain_ollama", types.SimpleNamespace(OllamaEmbedding
 
 from ingestion.email.ingest import _normalize, run_email_ingestion
 from ingestion.email.processor import EmailProcessor
+import ingestion.email.orchestrator as orchestrator_module
 
 
 @pytest.fixture
@@ -184,3 +185,136 @@ def test_email_processor_process_uses_dependencies(raw_email_record: Dict[str, A
 
     processor.manager.upsert_email.assert_called_once_with(record)
     milvus.add_embeddings.assert_called_once()
+
+
+def test_email_orchestrator_processes_multiple_accounts(monkeypatch: pytest.MonkeyPatch) -> None:
+    """EmailOrchestrator should fetch emails for each configured account."""
+
+    processed: list[str] = []
+
+    class DummyConnector:
+        def __init__(self, **kwargs: Any) -> None:
+            self.username = kwargs.get("username")
+
+        def fetch_emails(self):
+            processed.append(self.username)
+            return []
+
+    monkeypatch.setattr(orchestrator_module, "IMAPConnector", DummyConnector)
+
+    class DummyAccountManager:
+        def list_accounts(self):
+            return [
+                {
+                    "server_type": "imap",
+                    "server": "s1",
+                    "port": 1,
+                    "username": "u1",
+                    "password": "p",
+                    "use_ssl": 1,
+                },
+                {
+                    "server_type": "imap",
+                    "server": "s2",
+                    "port": 2,
+                    "username": "u2",
+                    "password": "p",
+                    "use_ssl": 1,
+                },
+            ]
+
+    class DummyConfig:
+        EMAIL_ENABLED = True
+        EMAIL_SYNC_INTERVAL_SECONDS = 0
+
+    orchestrator = orchestrator_module.EmailOrchestrator(
+        DummyConfig(), account_manager=DummyAccountManager()
+    )
+
+    class DummyEvent:
+        def __init__(self):
+            self.flag = False
+
+        def set(self):
+            self.flag = True
+
+        def is_set(self):
+            return self.flag
+
+        def wait(self, _):
+            self.flag = True
+
+    orchestrator._stop_event = DummyEvent()
+    orchestrator._run_loop()
+    assert processed == ["u1", "u2"]
+
+
+def test_run_email_ingestion_header_hash_dedup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Emails with duplicate header hashes should be skipped."""
+
+    class DummyConnector:
+        def fetch_emails(self, since_date=None):
+            base = {
+                "thread_id": None,
+                "subject": "Hi",
+                "from_addr": "a@example.com",
+                "to_addrs": ["b@example.com"],
+                "cc_addrs": [],
+                "date_utc": "2024-01-01",
+                "received_utc": None,
+                "in_reply_to": None,
+                "references_ids": [],
+                "is_reply": 0,
+                "is_forward": 0,
+                "raw_size_bytes": None,
+                "body_text": None,
+                "body_html": "<p>First</p>",
+                "language": None,
+                "has_attachments": 0,
+                "attachment_manifest": [],
+                "processed": 0,
+                "ingested_at": None,
+                "updated_at": None,
+                "content_hash": None,
+                "summary": None,
+                "keywords": None,
+                "auto_topic": None,
+                "manual_topic": None,
+                "topic_confidence": None,
+                "topic_version": None,
+                "error_state": None,
+                "direction": None,
+                "participants": [],
+                "participants_hash": None,
+                "to_primary": None,
+            }
+            rec1 = {"message_id": "1", **base}
+            rec2 = {"message_id": "1", **base, "body_html": "<p>Second</p>"}
+            return [rec1, rec2]
+
+    seen: set[str] = set()
+
+    def get_email_by_header_hash(hh: str):
+        if hh in seen:
+            return {"header_hash": hh}
+        seen.add(hh)
+        return None
+
+    manager = MagicMock()
+    manager.get_email_by_header_hash.side_effect = get_email_by_header_hash
+    manager.get_email_by_hash.return_value = None
+
+    class DummyProcessor:
+        def __init__(self):
+            self.manager = manager
+            self.processed: list[Dict[str, Any]] = []
+
+        def process(self, record: Dict[str, Any]) -> None:
+            self.processed.append(record)
+
+    connector = DummyConnector()
+    processor = DummyProcessor()
+    processed = run_email_ingestion(connector, processor)
+    assert processed == 1
+    assert len(processor.processed) == 1
+    assert manager.get_email_by_header_hash.call_count == 2


### PR DESCRIPTION
## Summary
- add CRUD tests for EmailAccountManager and Flask routes
- test orchestrator processing multiple email accounts
- ensure run_email_ingestion deduplicates by header hash

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a138b018ac83218ee9bf88aba879e9