### PR TITLE
docs: add Realm Tiles prompt documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,5 +10,6 @@ The application forms a RAG-focused data lake using Milvus for vector embeddings
 - [System Architecture](architecture.md)
 - [Contributing](contributing.md)
 - [Roadmap](roadmap.md)
+- [Realm Tiles Prompt](realm_tiles_prompt.md)
 
 Each document describes the current state of the project and notes areas that still need to be built.

--- a/docs/realm_tiles_prompt.md
+++ b/docs/realm_tiles_prompt.md
@@ -1,0 +1,7 @@
+# Realm Tiles Prompt Definition
+
+The following prompt is used to generate seamless terrain tiles for a top-down RPG asset pack:
+
+> Draw picture for a top down RPG asset pack of a tile image of a flat grounds with no large vegetation or bolder or large objects. Filling the entire image with one environment type. Images should use tiling so the image can be seamlessly stitch together.
+
+This description instructs the image generation model to create a single tile containing a flat, uniform environment free of large objects so that multiple copies of the tile can be seamlessly stitched together on a game map.


### PR DESCRIPTION
## Summary
- document prompt definition for generating seamless Realm Tiles
- link new prompt documentation from docs index

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a138054fb08321bc5e39a8782096fe