### PR TITLE
docs: document email account management

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -26,6 +26,41 @@ The application exposes a Flask web interface for managing documents and perform
 - **Semantic Search** – query stored documents via vector search.
 - **RAG Chat** – ask questions and receive answers synthesized from relevant documents.
 
+## Managing Email Accounts
+
+The dashboard includes an **Email Accounts** section for configuring IMAP
+sources.
+
+### Adding Accounts
+
+1. Click **Add Email Account** to open the form.
+2. Complete all required fields:
+   - **Display Name** – unique label for the account.
+   - **Server** – IMAP server hostname.
+   - **Port** – connection port number.
+   - **Username** – account login name.
+   - **Password** – account password.
+   Optional fields include **Mailbox** (defaults to `INBOX`), **Batch Limit**,
+   and **Use SSL**.
+3. Submit the form to save the account.
+
+### Editing or Deleting
+
+- Use the pencil icon to edit an existing account, update the fields, and
+  select **Save changes**.
+- Use the trash icon to remove an account; deletion requires confirmation.
+
+### Security & Sync Intervals
+
+Credentials are stored in the local `knowledgebase.db` SQLite database. They
+are kept in plain text, so restrict filesystem access or employ disk
+encryption when using sensitive accounts.
+
+All configured accounts are synchronized by a background job every
+`EMAIL_SYNC_INTERVAL_SECONDS` seconds (default: `300`). Adjust this environment
+variable before starting the application to change how frequently emails are
+fetched.
+
 ## TODOs
 
 - [ ] Command-line interface for batch operations.


### PR DESCRIPTION
## Summary
- add documentation for adding, editing, and deleting email accounts in the UI
- describe required fields, credential storage security, and sync intervals

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a13f6bf1208321a52debb347f07b6d