### PR TITLE
Add Gmail connector and dependencies

### DIFF
--- a/ingestion/email/__init__.py
+++ b/ingestion/email/__init__.py
@@ -1,6 +1,6 @@
 """Email ingestion connectors and orchestration utilities."""
 
-from .connector import EmailConnector, IMAPConnector
+from .connector import EmailConnector, IMAPConnector, GmailConnector
 from .orchestrator import EmailOrchestrator
 from .email_manager import EmailManager
 from .account_manager import EmailAccountManager
@@ -9,6 +9,7 @@ from .ingest import run_email_ingestion
 __all__ = [
     "EmailConnector",
     "IMAPConnector",
+    "GmailConnector",
     "EmailOrchestrator",
     "EmailManager",
     "EmailAccountManager",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
     "langchain-unstructured>=0.1.0",
     "unstructured[pdf]>=0.10.0",
     "cryptography>=41.0.0",
+    "google-api-python-client>=2.0.0",
+    "google-auth>=2.0.0",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Summary
- add Gmail API connector with pagination and Base64 decoding
- expose GmailConnector through package init
- include google-api-python-client and google-auth dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a14b6f65008321a9710e6e63f19a89