### PR TITLE
docs: add email encryption key example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,3 +47,8 @@ CRAWL_JITTER_SECONDS=0.3
 SCHEDULER_POLL_SECONDS_BUSY=10
 SCHEDULER_POLL_SECONDS_IDLE=30
 URL_DEFAULT_REFRESH_MINUTES=1440
+
+# Email settings
+# Symmetric key for encrypting stored email account passwords.
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+EMAIL_ENCRYPTION_KEY=


### PR DESCRIPTION
## Summary
- document EMAIL_ENCRYPTION_KEY in `.env.example`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a14deb3a148321b63856d3b1fc1ff7