### PR TITLE
Add email server type metadata and selection UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -1844,6 +1844,7 @@ class RAGKnowledgebaseManager:
         def add_email_account():
             """Create a new email account configuration."""
             account_name = request.form.get('account_name', '').strip()
+            server_type = request.form.get('server_type', 'imap').strip().lower() or 'imap'
             server = request.form.get('server', '').strip()
             username = request.form.get('username', '').strip()
             password = request.form.get('password', '').strip()
@@ -1867,7 +1868,7 @@ class RAGKnowledgebaseManager:
 
             record = {
                 'account_name': account_name,
-                'server_type': 'imap',
+                'server_type': server_type,
                 'server': server,
                 'port': port,
                 'username': username,
@@ -1900,12 +1901,15 @@ class RAGKnowledgebaseManager:
             batch_limit_str = request.form.get('batch_limit', '').strip()
             refresh_raw = request.form.get('refresh_interval_minutes', '').strip()
             use_ssl = request.form.get('use_ssl', '0') == '1'
+            server_type = request.form.get('server_type', '').strip()
 
             updates: Dict[str, Any] = {}
             if account_name:
                 updates['account_name'] = account_name
             if server:
                 updates['server'] = server
+            if server_type:
+                updates['server_type'] = server_type.lower()
             if username:
                 updates['username'] = username
             if password:

--- a/ingestion/email/connector.py
+++ b/ingestion/email/connector.py
@@ -97,7 +97,9 @@ class IMAPConnector(EmailConnector):
                 continue
             try:
                 msg = message_from_bytes(msg_data[0][1])
-                results.append(self._parse_email(msg))
+                rec = self._parse_email(msg)
+                rec["server_type"] = "imap"
+                results.append(rec)
             except Exception as exc:  # pragma: no cover - defensive
                 results.append(
                     {
@@ -134,6 +136,7 @@ class IMAPConnector(EmailConnector):
                         "participants": [],
                         "participants_hash": None,
                         "to_primary": None,
+                        "server_type": "imap",
                     }
                 )
         conn.logout()
@@ -367,7 +370,9 @@ class GmailConnector(EmailConnector):
                     try:
                         raw = base64.urlsafe_b64decode(msg_data.get("raw", "").encode("utf-8"))
                         msg = message_from_bytes(raw)
-                        results.append(self._parse_email(msg))
+                        rec = self._parse_email(msg)
+                        rec["server_type"] = "gmail"
+                        results.append(rec)
                     except Exception:
                         continue
                     fetched += 1

--- a/ingestion/email/email_manager.py
+++ b/ingestion/email/email_manager.py
@@ -77,7 +77,8 @@ class EmailManager:
                 participants TEXT,
                 participants_hash TEXT,
                 to_primary TEXT,
-                header_hash TEXT
+                header_hash TEXT,
+                server_type TEXT
             )
             '''
         )
@@ -89,6 +90,9 @@ class EmailManager:
             cursor.execute("ALTER TABLE emails ADD COLUMN header_hash TEXT")
             self.conn.commit()
             self._backfill_header_hash()
+        if "server_type" not in cols:
+            cursor.execute("ALTER TABLE emails ADD COLUMN server_type TEXT")
+            self.conn.commit()
 
     # ------------------------------------------------------------------
     def _backfill_header_hash(self) -> None:

--- a/ingestion/email/processor.py
+++ b/ingestion/email/processor.py
@@ -82,6 +82,7 @@ class EmailProcessor:
                 "from_addr": record.get("from_addr"),
                 "to_addrs": record.get("to_addrs"),
                 "date_utc": record.get("date_utc"),
+                "server_type": record.get("server_type"),
             }
             metadatas.append(meta)
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -514,7 +514,8 @@
                                                             data-mailbox="{{ acct.mailbox or '' }}"
                                                             data-batch="{{ acct.batch_limit or '' }}"
                                                             data-interval="{{ acct.refresh_interval_minutes or '' }}"
-                                                            data-ssl="{{ '1' if acct.use_ssl else '0' }}">
+                                                            data-ssl="{{ '1' if acct.use_ssl else '0' }}"
+                                                            data-type="{{ acct.server_type }}">
                                                         <i class="fas fa-pen"></i>
                                                     </button>
                                                     <button type="button" class="btn btn-outline-danger delete-account-btn"
@@ -554,6 +555,13 @@
                             <div class="mb-3">
                                 <label class="form-label">Display Name</label>
                                 <input type="text" class="form-control" name="account_name" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Server Type</label>
+                                <select class="form-select" name="server_type" required>
+                                    <option value="imap">IMAP</option>
+                                    <option value="gmail">Gmail</option>
+                                </select>
                             </div>
                             <div class="mb-3">
                                 <label class="form-label">Server</label>
@@ -615,6 +623,13 @@
                             <div class="mb-3">
                                 <label class="form-label">Display Name</label>
                                 <input type="text" class="form-control" name="account_name" id="editAccountName" required>
+                            </div>
+                            <div class="mb-3">
+                                <label class="form-label">Server Type</label>
+                                <select class="form-select" name="server_type" id="editServerType" required>
+                                    <option value="imap">IMAP</option>
+                                    <option value="gmail">Gmail</option>
+                                </select>
                             </div>
                             <div class="mb-3">
                                 <label class="form-label">Server</label>
@@ -997,6 +1012,7 @@
                     document.getElementById('editBatchLimit').value = btn.dataset.batch || '';
                     document.getElementById('editRefreshInterval').value = btn.dataset.interval || '';
                     document.getElementById('editUseSSL').checked = btn.dataset.ssl === '1';
+                    document.getElementById('editServerType').value = btn.dataset.type || 'imap';
                 });
             });
             // Populate delete confirmation modal

--- a/tests/test_email_accounts.py
+++ b/tests/test_email_accounts.py
@@ -159,6 +159,7 @@ def test_email_account_crud(client):
         "/email_accounts",
         data={
             "account_name": "Work",
+            "server_type": "imap",
             "server": "imap.example.com",
             "username": "user",
             "password": "pass",

--- a/tests/test_email_ingestion.py
+++ b/tests/test_email_ingestion.py
@@ -80,6 +80,7 @@ def raw_email_record() -> Dict[str, Any]:
         "participants": [],
         "participants_hash": None,
         "to_primary": None,
+        "server_type": "imap",
     }
 
 
@@ -136,6 +137,7 @@ def test_run_email_ingestion_deduplicates() -> None:
                 "participants": [],
                 "participants_hash": None,
                 "to_primary": None,
+                "server_type": "imap",
             }
             rec1 = {"message_id": "1", **base}
             rec2 = {"message_id": "1", **base, "body_html": "<p>Second</p>"}
@@ -315,6 +317,7 @@ def test_run_email_ingestion_header_hash_dedup(monkeypatch: pytest.MonkeyPatch) 
                 "participants": [],
                 "participants_hash": None,
                 "to_primary": None,
+                "server_type": "imap",
             }
             rec1 = {"message_id": "1", **base}
             rec2 = {"message_id": "1", **base, "body_html": "<p>Second</p>"}

--- a/tests/test_gmail_connector.py
+++ b/tests/test_gmail_connector.py
@@ -59,3 +59,4 @@ def test_gmail_fetch_emails_returns_canonical_records(monkeypatch: pytest.Monkey
     assert record["body_text"].strip() == "Hi Bob"
     assert record["has_attachments"] == 1
     assert record["attachment_manifest"][0]["filename"] == "note.txt"
+    assert record["server_type"] == "gmail"


### PR DESCRIPTION
## Summary
- track connector server type on stored emails and embeddings
- support specifying server type when adding or editing email accounts
- expose server type selector in account management UI

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a1e55873e483218e8122f47cc5d47e