### PR TITLE
feat: add Exchange email connector

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ The application forms a RAG-focused data lake using Milvus for vector embeddings
 - [System Architecture](architecture.md)
 - [Contributing](contributing.md)
 - [Gmail Email Ingestion](gmail_ingestion.md)
+- [Exchange Email Ingestion](exchange_ingestion.md)
 - [Roadmap](roadmap.md)
 - [Realm Tiles Prompt](realm_tiles_prompt.md)
 

--- a/docs/exchange_ingestion.md
+++ b/docs/exchange_ingestion.md
@@ -1,0 +1,43 @@
+# Exchange Email Ingestion
+
+This guide covers how to ingest emails from an Exchange server into RAG Document Handler.
+
+## Prerequisites
+
+1. **Exchange credentials**
+   - Obtain the server URL, username, and password for the Exchange account.
+   - The connector uses the [exchangelib](https://github.com/ecederstrand/exchangelib) library and connects via Exchange Web Services (EWS).
+2. **Configure RAG Document Handler**
+   - Set `EMAIL_ENABLED=true` in your environment to activate email ingestion.
+   - Configure `EMAIL_SYNC_INTERVAL_SECONDS` to control how often accounts are synchronized (default `300`).
+   - Add an Exchange account to the `email_accounts` table (via UI or SQL) with the following fields:
+     - `server_type`: `exchange`
+     - `server`: the EWS server hostname
+     - `username`: your account's primary email address
+     - `password`: the account password
+     - Optional: `batch_limit` to cap messages fetched per sync
+
+## Minimal Example
+
+```python
+from datetime import datetime
+
+from exchangelib import Credentials
+from ingestion.email.connector import ExchangeConnector
+
+creds = Credentials(username="user@example.com", password="password")
+connector = ExchangeConnector(
+    server="exchange.example.com",
+    username="user@example.com",
+    password="password",
+)
+
+records = connector.fetch_emails(since_date=datetime(2024, 1, 1))
+print(len(records))
+```
+
+## Limitations & Scheduling
+
+- **Permissions**: the account must have EWS access enabled.
+- **Batch size**: the connector fetches messages in descending order by received date and can be limited with `batch_limit`.
+- **Scheduling**: run the `EmailOrchestrator` with `EMAIL_ENABLED=true`, or call `run_email_ingestion` from a cron job at the desired interval.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -28,15 +28,15 @@ The application exposes a Flask web interface for managing documents and perform
 
 ## Managing Email Accounts
 
-The dashboard includes an **Email Accounts** section for configuring IMAP
-sources.
+The dashboard includes an **Email Accounts** section for configuring IMAP,
+Gmail, or Exchange sources.
 
 ### Adding Accounts
 
 1. Click **Add Email Account** to open the form.
 2. Complete all required fields:
    - **Display Name** – unique label for the account.
-   - **Server** – IMAP server hostname.
+   - **Server** – mail server hostname or EWS endpoint.
    - **Port** – connection port number.
    - **Username** – account login name.
    - **Password** – account password.

--- a/ingestion/email/__init__.py
+++ b/ingestion/email/__init__.py
@@ -1,6 +1,6 @@
 """Email ingestion connectors and orchestration utilities."""
 
-from .connector import EmailConnector, IMAPConnector, GmailConnector
+from .connector import EmailConnector, IMAPConnector, GmailConnector, ExchangeConnector
 from .orchestrator import EmailOrchestrator
 from .email_manager import EmailManager
 from .account_manager import EmailAccountManager
@@ -10,6 +10,7 @@ __all__ = [
     "EmailConnector",
     "IMAPConnector",
     "GmailConnector",
+    "ExchangeConnector",
     "EmailOrchestrator",
     "EmailManager",
     "EmailAccountManager",

--- a/ingestion/email/orchestrator.py
+++ b/ingestion/email/orchestrator.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 from google.auth.transport.requests import Request
 from google.oauth2.credentials import Credentials
 
-from .connector import IMAPConnector, GmailConnector
+from .connector import IMAPConnector, GmailConnector, ExchangeConnector
 from .account_manager import EmailAccountManager
 
 logger = logging.getLogger(__name__)
@@ -111,6 +111,13 @@ class EmailOrchestrator:
                     connector = GmailConnector(
                         credentials=creds,
                         user_id=account.get("username") or "me",
+                        batch_limit=batch_limit,
+                    )
+                elif server_type == "exchange":
+                    connector = ExchangeConnector(
+                        server=account["server"],
+                        username=account["username"],
+                        password=account["password"],
                         batch_limit=batch_limit,
                     )
                 else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ dependencies = [
     "cryptography>=41.0.0",
     "google-api-python-client>=2.0.0",
     "google-auth>=2.0.0",
+    "exchangelib>=5.0.0",
 ]
 
 [project.optional-dependencies]

--- a/templates/index.html
+++ b/templates/index.html
@@ -561,6 +561,7 @@
                                 <select class="form-select" name="server_type" required>
                                     <option value="imap">IMAP</option>
                                     <option value="gmail">Gmail</option>
+                                    <option value="exchange">Exchange</option>
                                 </select>
                             </div>
                             <div class="mb-3">
@@ -629,6 +630,7 @@
                                 <select class="form-select" name="server_type" id="editServerType" required>
                                     <option value="imap">IMAP</option>
                                     <option value="gmail">Gmail</option>
+                                    <option value="exchange">Exchange</option>
                                 </select>
                             </div>
                             <div class="mb-3">

--- a/tests/test_exchange_connector.py
+++ b/tests/test_exchange_connector.py
@@ -1,0 +1,82 @@
+"""Tests for ExchangeConnector fetching and normalization."""
+
+from __future__ import annotations
+
+import os
+import sys
+import types
+from typing import Any
+
+import pytest
+
+# Stub external dependencies to avoid heavy installs
+sys.modules.setdefault("google.oauth2.credentials", types.SimpleNamespace(Credentials=object))
+sys.modules.setdefault("googleapiclient.discovery", types.SimpleNamespace(build=lambda *a, **k: None))
+sys.modules.setdefault("googleapiclient.errors", types.SimpleNamespace(HttpError=Exception))
+sys.modules.setdefault(
+    "exchangelib",
+    types.SimpleNamespace(Account=object, Configuration=object, Credentials=object, DELEGATE=object),
+)
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import importlib.util
+
+connector_path = os.path.join(
+    os.path.abspath(os.path.join(os.path.dirname(__file__), "..")),
+    "ingestion",
+    "email",
+    "connector.py",
+)
+spec = importlib.util.spec_from_file_location("exchange_connector", connector_path)
+connector_module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(connector_module)
+ExchangeConnector = connector_module.ExchangeConnector
+
+
+def test_exchange_fetch_emails_returns_canonical_records(monkeypatch: pytest.MonkeyPatch) -> None:
+    raw_email = (
+        "Subject: Hello\r\n"
+        "From: Alice <alice@example.com>\r\n"
+        "To: Bob <bob@example.com>\r\n"
+        "Date: Mon, 01 Jan 2024 00:00:00 +0000\r\n"
+        "Message-ID: <e1@example.com>\r\n"
+        "\r\n"
+        "Hi Bob\r\n"
+    ).encode("utf-8")
+
+    item = types.SimpleNamespace(mime_content=raw_email)
+
+    class FakeQuery:
+        def __init__(self, items: list[Any]) -> None:
+            self.items = items
+
+        def all(self) -> "FakeQuery":
+            return self
+
+        def order_by(self, *args: Any, **kwargs: Any) -> "FakeQuery":
+            return self
+
+        def __getitem__(self, key: slice) -> list[Any]:
+            return self.items[key]
+
+        def __iter__(self):
+            return iter(self.items)
+
+    fake_account = types.SimpleNamespace(inbox=FakeQuery([item]))
+
+    monkeypatch.setattr(connector_module, "Account", lambda *a, **k: fake_account)
+    monkeypatch.setattr(connector_module, "EWSCredentials", lambda *a, **k: None)
+    monkeypatch.setattr(connector_module, "Configuration", lambda *a, **k: None)
+
+    connector = ExchangeConnector(
+        server="ex.example.com",
+        username="user@example.com",
+        password="pass",
+        batch_limit=10,
+    )
+    records = connector.fetch_emails()
+    assert len(records) == 1
+    record = records[0]
+    assert record["from_addr"] == "alice@example.com"
+    assert record["to_addrs"] == ["bob@example.com"]
+    assert record["server_type"] == "exchange"


### PR DESCRIPTION
## Summary
- add ExchangeConnector using exchangelib
- expose Exchange server option in UI and orchestrator
- document Exchange ingestion and add regression tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a1ea17be5c8321838769bea3767d60