### PR TITLE
Fix email orchestrator scheduling for accounts

### DIFF
--- a/app.py
+++ b/app.py
@@ -1424,7 +1424,11 @@ class RAGKnowledgebaseManager:
 
         # Start email orchestrator if enabled
         try:
-            self.email_orchestrator = EmailOrchestrator(self.config)
+            email_conn = sqlite3.connect(self.url_manager.db_path, check_same_thread=False)
+            self.email_account_manager = EmailAccountManager(email_conn)
+            self.email_orchestrator = EmailOrchestrator(
+                self.config, self.email_account_manager
+            )
             self.email_orchestrator.start()
         except Exception as e:
             logger.error(f"Failed to start email orchestrator: {e}")


### PR DESCRIPTION
## Summary
- ensure EmailOrchestrator receives EmailAccountManager
- start orchestration with database connection for email accounts

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a20c460c74832190fe75509233b5cb