### PR TITLE
feat: add manual email refresh

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -518,6 +518,11 @@
                                                             data-type="{{ acct.server_type }}">
                                                         <i class="fas fa-pen"></i>
                                                     </button>
+                                                    <form method="POST" action="{{ url_for('refresh_email_account', account_id=acct.id) }}">
+                                                        <button type="submit" class="btn btn-outline-primary" title="Refresh now">
+                                                            <i class="fas fa-sync"></i>
+                                                        </button>
+                                                    </form>
                                                     <button type="button" class="btn btn-outline-danger delete-account-btn"
                                                             data-bs-toggle="modal" data-bs-target="#deleteEmailAccountModal"
                                                             data-action="{{ url_for('delete_email_account', account_id=acct.id) }}"


### PR DESCRIPTION
## Summary
- add refresh button for email accounts on index page
- allow manual email sync via new endpoint and background worker

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a20fbefea483218091de024e8bc507