### PR TITLE
feat: display email server type

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -484,9 +484,10 @@
                                     <thead class="table-light">
                                         <tr>
                                             <th>Display Name</th>
+                                            <th>Server Type</th>
                                             <th>Server</th>
                                             <th>Username</th>
-                                            <th>Schedule</th>
+                                            <th>Schedule / Time</th>
                                             <th class="text-end">Actions</th>
                                         </tr>
                                     </thead>
@@ -494,6 +495,7 @@
                                     {% for acct in email_accounts %}
                                         <tr>
                                             <td>{{ acct.account_name }}</td>
+                                            <td>{{ {'imap': 'IMAP', 'gmail': 'Gmail', 'exchange': 'Exchange'}.get(acct.server_type, acct.server_type) }}</td>
                                             <td>{{ acct.server }}:{{ acct.port }}</td>
                                             <td>{{ acct.username }}</td>
                                             <td class="small">


### PR DESCRIPTION
## Summary
- show each email account's server type in the Email Accounts table
- rename Schedule column to Schedule / Time for consistency with the URL manager

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a21346232c8321800f78db497cfd10