### PR TITLE
Add email account refresh status tracking

### DIFF
--- a/ingestion/email/account_manager.py
+++ b/ingestion/email/account_manager.py
@@ -37,7 +37,8 @@ class EmailAccountManager:
                 batch_limit INTEGER,
                 use_ssl INTEGER,
                 refresh_interval_minutes INTEGER,
-                last_synced TIMESTAMP
+                last_synced TIMESTAMP,
+                last_update_status TEXT
             )
             """
         )
@@ -51,6 +52,10 @@ class EmailAccountManager:
         if "last_synced" not in existing:
             cur.execute(
                 "ALTER TABLE email_accounts ADD COLUMN last_synced TIMESTAMP"
+            )
+        if "last_update_status" not in existing:
+            cur.execute(
+                "ALTER TABLE email_accounts ADD COLUMN last_update_status TEXT"
             )
         self.conn.commit()
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -488,6 +488,7 @@
                                             <th>Server</th>
                                             <th>Username</th>
                                             <th>Schedule / Time</th>
+                                            <th>Status</th>
                                             <th class="text-end">Actions</th>
                                         </tr>
                                     </thead>
@@ -502,6 +503,26 @@
                                                 <div>Every {{ acct.refresh_interval_minutes or config.EMAIL_DEFAULT_REFRESH_MINUTES }} min</div>
                                                 <div class="text-muted">Last: {{ (acct.last_synced or '')[:16] if acct.last_synced else '—' }}</div>
                                                 <div class="text-muted">Next: {{ (acct.next_run or '')[:16] if acct.next_run else '—' }}</div>
+                                            </td>
+                                            <td>
+                                                {% set up = email_processing_status.get(acct.id) if email_processing_status else None %}
+                                                {% if up %}
+                                                    <div class="small mb-1">
+                                                        <span class="badge bg-info" title="{{ up.message }}">{{ up.status.title() }}</span>
+                                                    </div>
+                                                    <div class="progress progress-custom">
+                                                        <div class="progress-bar bg-success progress-animated"
+                                                             role="progressbar" aria-valuemin="0" aria-valuemax="100"
+                                                             data-email-id="{{ acct.id }}"
+                                                             data-initial-progress="{{ up.progress or 0 }}"
+                                                             style="width: 0%"></div>
+                                                    </div>
+                                                {% elif acct.last_update_status %}
+                                                    {% set status_text = acct.last_update_status %}
+                                                    <span class="badge {% if status_text.startswith('error') %}bg-light text-dark{% else %}bg-success{% endif %}">{{ status_text }}</span>
+                                                {% else %}
+                                                    <span class="text-muted small">—</span>
+                                                {% endif %}
                                             </td>
                                             <td class="text-end">
                                                 <div class="btn-group btn-group-sm" role="group">
@@ -965,6 +986,69 @@
                 setInterval(refreshUrlStatuses, 1500);
                 // Initialize URL bars
                 refreshUrlStatuses();
+
+                function refreshEmailStatuses() {
+                    document.querySelectorAll('.progress-bar[data-email-id]').forEach(pb => {
+                        const acctId = pb.getAttribute('data-email-id');
+                        fetch(`/email_status/${acctId}`)
+                            .then(r => r.json())
+                            .then(data => {
+                                if (!data) return;
+                                if (data.status === 'deleted') {
+                                    const row = pb.closest('tr');
+                                    if (row) {
+                                        row.style.transition = 'opacity 200ms ease';
+                                        row.style.opacity = '0';
+                                        setTimeout(() => row.remove(), 220);
+                                    }
+                                    return;
+                                }
+                                if (data.status === 'not_found') {
+                                    try {
+                                        const td = pb.closest('td');
+                                        if (td) {
+                                            const statusText = data.last_update_status || '—';
+                                            const cls = statusText.startsWith('error') ? 'bg-light text-dark' : 'bg-success';
+                                            td.innerHTML = `<span class="badge ${cls}">${statusText}</span>`;
+                                        }
+                                        const row = td ? td.closest('tr') : null;
+                                        if (row) {
+                                            const timesCell = row.children[4];
+                                            if (timesCell) {
+                                                const lines = timesCell.querySelectorAll('div');
+                                                if (lines && lines.length >= 3) {
+                                                    const lastVal = data.last_synced ? String(data.last_synced).slice(0,16) : '—';
+                                                    lines[1].textContent = `Last: ${lastVal}`;
+                                                    const nextVal = data.next_run ? String(data.next_run).slice(0,16) : '—';
+                                                    lines[2].textContent = `Next: ${nextVal}`;
+                                                }
+                                            }
+                                        }
+                                    } catch (e) { /* no-op */ }
+                                    return;
+                                }
+                                const pct = typeof data.progress === 'number' ? data.progress : 0;
+                                pb.style.width = `${pct}%`;
+                                pb.setAttribute('aria-valuenow', String(pct));
+                                if (["queued","processing","chunking","embedding","storing"].includes(data.status)) {
+                                    pb.classList.add('progress-animated');
+                                } else {
+                                    pb.classList.remove('progress-animated');
+                                }
+                                if (data.status === 'completed' || data.status === 'error') {
+                                    const td = pb.closest('td');
+                                    if (td) {
+                                        const s = data.status === 'completed' ? (data.last_update_status || 'updated') : `error`;
+                                        const cls = s.startsWith('error') ? 'bg-light text-dark' : 'bg-success';
+                                        td.innerHTML = `<span class="badge ${cls}">${s}</span>`;
+                                    }
+                                }
+                            })
+                            .catch(() => {});
+                    });
+                }
+                setInterval(refreshEmailStatuses, 1500);
+                refreshEmailStatuses();
             pb.style.width = `${init}%`;
             pb.setAttribute('aria-valuenow', String(init));
             if (init >= 100) {

--- a/tests/test_email_ingestion.py
+++ b/tests/test_email_ingestion.py
@@ -30,8 +30,8 @@ class _DummyEmbeddings:
         return [[0.0] * 1 for _ in docs]
 
 
-sys.modules.setdefault("langchain_text_splitters", types.SimpleNamespace(RecursiveCharacterTextSplitter=_DummySplitter))
-sys.modules.setdefault("langchain_ollama", types.SimpleNamespace(OllamaEmbeddings=_DummyEmbeddings))
+sys.modules["langchain_text_splitters"] = types.SimpleNamespace(RecursiveCharacterTextSplitter=_DummySplitter)
+sys.modules["langchain_ollama"] = types.SimpleNamespace(OllamaEmbeddings=_DummyEmbeddings)
 sys.modules.setdefault("google.oauth2.credentials", types.SimpleNamespace(Credentials=object))
 sys.modules.setdefault("googleapiclient.discovery", types.SimpleNamespace(build=lambda *a, **k: None))
 sys.modules.setdefault("googleapiclient.errors", types.SimpleNamespace(HttpError=Exception))

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -29,7 +29,7 @@ sys.modules.setdefault("chardet", types.SimpleNamespace(detect=lambda *a, **k: {
 _ollama = types.ModuleType("langchain_ollama")
 _ollama.OllamaEmbeddings = lambda *a, **k: None
 _ollama.ChatOllama = lambda *a, **k: None
-sys.modules.setdefault("langchain_ollama", _ollama)
+sys.modules["langchain_ollama"] = _ollama
 sys.modules.setdefault(
     "langchain_community.vectorstores",
     types.SimpleNamespace(Milvus=types.SimpleNamespace(from_texts=lambda *a, **k: None)),


### PR DESCRIPTION
## Summary
- Track email refresh outcomes with `last_update_status`
- Expose `/email_status/<id>` endpoint and surface status in UI
- Poll email refresh progress and update schedule timestamps dynamically

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a23548f1d88321b76d24a09b325053