### PR TITLE
Handle IMAP failures and ensure logout

### DIFF
--- a/tests/test_imap_connector.py
+++ b/tests/test_imap_connector.py
@@ -34,8 +34,9 @@ class DummyIMAP4:
         self.calls.append("starttls")
         return "OK", b""
 
-    def login(self, *_: Any, **__: Any) -> None:  # pragma: no cover - interface stub
+    def login(self, *_: Any, **__: Any):  # pragma: no cover - interface stub
         self.calls.append("login")
+        return "OK", [b""]
 
     def select(self, *_: Any, **__: Any):  # pragma: no cover - interface stub
         return "OK", [b"0"]


### PR DESCRIPTION
## Summary
- Validate IMAP login, mailbox selection, and search responses and log warnings on failures
- Log message ID and exception when email parsing fails
- Always attempt IMAP logout and log disconnect errors
- Adjust IMAP connector tests for new status checks

## Testing
- `pytest tests/test_imap_connector.py::test_imap_connector_uses_starttls -q`
- `pytest tests/test_imap_connector.py::test_imap_connector_starttls_failure -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a239089ce4832199a9936cc4dfbfaa