### PR TITLE
Fix SSL toggle state on email account editor

### DIFF
--- a/app.py
+++ b/app.py
@@ -1913,7 +1913,7 @@ class RAGKnowledgebaseManager:
             mailbox = request.form.get('mailbox', '').strip() or None
             batch_limit_str = request.form.get('batch_limit', '').strip()
             refresh_raw = request.form.get('refresh_interval_minutes', '').strip()
-            use_ssl = request.form.get('use_ssl', '0') == '1'
+            use_ssl = request.form.get('use_ssl') in ('1', 'on')
 
             logger.info(
                 "Request to add email account '%s' (%s) on %s by user %s",
@@ -1973,7 +1973,7 @@ class RAGKnowledgebaseManager:
             mailbox = request.form.get('mailbox', '').strip() or None
             batch_limit_str = request.form.get('batch_limit', '').strip()
             refresh_raw = request.form.get('refresh_interval_minutes', '').strip()
-            use_ssl = request.form.get('use_ssl', '0') == '1'
+            use_ssl = request.form.get('use_ssl') in ('1', 'on')
             server_type = request.form.get('server_type', '').strip()
 
             updates: Dict[str, Any] = {}

--- a/templates/index.html
+++ b/templates/index.html
@@ -617,18 +617,18 @@
                                 </div>
                             </div>
                             <div class="row">
-                                <div class="col-md-4 mb-3">
+                                <div class="col-md-6 mb-3">
                                     <label class="form-label">Batch Limit</label>
                                     <input type="number" class="form-control" name="batch_limit">
                                 </div>
-                                <div class="col-md-4 mb-3">
+                                <div class="col-md-6 mb-3">
                                     <label class="form-label">Refresh interval (minutes)</label>
                                     <input type="number" class="form-control" name="refresh_interval_minutes" value="{{ config.EMAIL_DEFAULT_REFRESH_MINUTES }}">
                                 </div>
-                                <div class="col-md-4 mb-3 form-check form-switch">
-                                    <input class="form-check-input" type="checkbox" name="use_ssl" id="addUseSSL">
-                                    <label class="form-check-label" for="addUseSSL">Use SSL</label>
-                                </div>
+                            </div>
+                            <div class="mb-3 form-check form-switch">
+                                <input class="form-check-input" type="checkbox" name="use_ssl" id="addUseSSL" value="1">
+                                <label class="form-check-label" for="addUseSSL">Use SSL</label>
                             </div>
                         </div>
                         <div class="modal-footer">
@@ -686,18 +686,18 @@
                                 </div>
                             </div>
                             <div class="row">
-                                <div class="col-md-4 mb-3">
+                                <div class="col-md-6 mb-3">
                                     <label class="form-label">Batch Limit</label>
                                     <input type="number" class="form-control" name="batch_limit" id="editBatchLimit">
                                 </div>
-                                <div class="col-md-4 mb-3">
+                                <div class="col-md-6 mb-3">
                                     <label class="form-label">Refresh interval (minutes)</label>
                                     <input type="number" class="form-control" name="refresh_interval_minutes" id="editRefreshInterval">
                                 </div>
-                                <div class="col-md-4 mb-3 form-check form-switch">
-                                    <input class="form-check-input" type="checkbox" name="use_ssl" id="editUseSSL">
-                                    <label class="form-check-label" for="editUseSSL">Use SSL</label>
-                                </div>
+                            </div>
+                            <div class="mb-3 form-check form-switch">
+                                <input class="form-check-input" type="checkbox" name="use_ssl" id="editUseSSL" value="1">
+                                <label class="form-check-label" for="editUseSSL">Use SSL</label>
                             </div>
                         </div>
                         <div class="modal-footer">
@@ -1108,7 +1108,7 @@
                     document.getElementById('editMailbox').value = btn.dataset.mailbox || '';
                     document.getElementById('editBatchLimit').value = btn.dataset.batch || '';
                     document.getElementById('editRefreshInterval').value = btn.dataset.interval || '';
-                    document.getElementById('editUseSSL').checked = btn.dataset.ssl === '1';
+                    document.getElementById('editUseSSL').checked = ['1','true','on'].includes(btn.dataset.ssl);
                     document.getElementById('editServerType').value = btn.dataset.type || 'imap';
                 });
             });

--- a/tests/test_email_accounts.py
+++ b/tests/test_email_accounts.py
@@ -167,7 +167,7 @@ def test_email_account_crud(client):
             "port": "993",
             "mailbox": "INBOX",
             "batch_limit": "10",
-            "use_ssl": "1",
+            "use_ssl": "on",
             "refresh_interval_minutes": "5",
         },
     )
@@ -180,6 +180,7 @@ def test_email_account_crud(client):
     account_id = accounts[0]["id"]
     assert "password" not in accounts[0]
     assert accounts[0]["refresh_interval_minutes"] == 5
+    assert accounts[0]["use_ssl"] == 1
     assert "last_update_status" in accounts[0]
     assert accounts[0]["last_update_status"] is None
 


### PR DESCRIPTION
## Summary
- ensure email account Use SSL option persists by reading form values of `1` or `on`
- move Use SSL switch to its own line and include explicit value so state is saved
- test coverage for persisting Use SSL flag

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a245d9adbc8321843eac1d3ac99644