### PR TITLE
Add deployment tooling and packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Build and publish package
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run: |
+          python -m pip install --upgrade pip build twine
+          python -m build
+          twine upload dist/*
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ${{ secrets.DOCKERHUB_USERNAME }}/rag-document-handler:latest
+            ${{ secrets.DOCKERHUB_USERNAME }}/rag-document-handler:${{ github.ref_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+# Set work directory
+WORKDIR /app
+
+# Install application
+COPY . /app
+RUN pip install --no-cache-dir .
+
+# Default environment variables
+ENV FLASK_HOST=0.0.0.0 \
+    FLASK_PORT=3000 \
+    MILVUS_HOST=milvus \
+    MILVUS_PORT=19530
+
+# Expose port
+EXPOSE 3000
+
+# Run the application
+CMD ["python", "app.py"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 Tony Philip
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  app:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      MILVUS_HOST: milvus
+      MILVUS_PORT: 19530
+    depends_on:
+      - milvus
+  milvus:
+    image: milvusdb/milvus:latest
+    ports:
+      - "19530:19530"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -20,6 +20,17 @@ cd rag-document-handler
 
 The setup script installs dependencies, prepares Milvus, and initializes the local SQLite database (`knowledgebase.db`). The start script launches Milvus (if needed) and runs the web application.
 
+## Docker Compose Deployment
+
+The repository includes a `docker-compose.yml` for running the web application together with a Milvus vector database.
+
+```bash
+cp .env.example .env  # optional configuration
+docker compose up -d
+```
+
+This builds the application image, starts Milvus, and exposes the web interface on [http://localhost:3000](http://localhost:3000).
+
 ## Manual Installation
 
 1. **Create virtual environment**
@@ -29,9 +40,8 @@ The setup script installs dependencies, prepares Milvus, and initializes the loc
    ```
 2. **Install Python dependencies**
    ```bash
-   pip install -e .
+   pip install rag-document-handler
    ```
-   > TODO: Publish an official package so users can run `pip install rag-document-handler`.
 3. **Run Milvus**
    ```bash
    docker run -d --name milvus -p 19530:19530 milvusdb/milvus:latest
@@ -78,7 +88,3 @@ export EMAIL_ENCRYPTION_KEY="<output-from-command>"
 Keep this value secret and **do not** commit it to version control. If the key
 is rotated, previously stored passwords will need to be re-entered.
 
-## TODOs
-
-- [ ] Provide Docker Compose configuration for full-stack deployment.
-- [ ] Publish package on PyPI for `pip install rag-document-handler`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,13 +15,14 @@ keywords = ["rag", "milvus", "document-management", "url-management", "web-scrap
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
 ]
+
+license = "MIT"
 
 dependencies = [
     "flask>=2.3.0",
@@ -62,7 +63,10 @@ Repository = "https://github.com/tonyphilip/rag-document-handler"
 Documentation = "https://github.com/tonyphilip/rag-document-handler#readme"
 
 [tool.setuptools]
-py-modules = ["app", "config"]
+py-modules = ["app"]
+
+[project.scripts]
+rag-document-handler = "app:main"
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
## Summary
- Provide Dockerfile and docker-compose for full-stack deployment
- Document Docker Compose usage and PyPI installation steps
- Add metadata and release workflow for publishing package and container

## Testing
- `pytest`
- `python -m build`


------
https://chatgpt.com/codex/tasks/task_e_68a265f1f75c8321a1e16072cec3fab9