### PR TITLE
Log Gmail API errors

### DIFF
--- a/ingestion/email/connector.py
+++ b/ingestion/email/connector.py
@@ -501,8 +501,9 @@ class GmailConnector(EmailConnector):
                     self.batch_limit is not None and fetched >= self.batch_limit
                 ):
                     break
-        except HttpError:
-            pass
+        except HttpError as exc:
+            logger.warning("Gmail API error: %s", exc)
+            return []
         logger.info(
             "Retrieved %d emails from Gmail for user %s", len(results), self.user_id
         )


### PR DESCRIPTION
## Summary
- log Gmail API errors and return no records
- test Gmail connector logs HttpError

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a269883d988321b1d85d51a4207fc0