### PR TITLE
fix: update status panel to show PostgreSQL version instead of SQLite

### DIFF
--- a/ingestion/postgres_manager.py
+++ b/ingestion/postgres_manager.py
@@ -306,6 +306,30 @@ class PostgreSQLManager:
                 result = cur.fetchone()
                 return result['analytics'] if result else {}
     
+    def get_version_info(self) -> Dict[str, Any]:
+        """Get PostgreSQL version and connection info."""
+        try:
+            with self.get_connection() as conn:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT version()")
+                    version_result = cur.fetchone()
+                    version_str = version_result['version'] if version_result else "Unknown"
+                    
+                    # Extract just the version number (e.g., "PostgreSQL 15.4")
+                    version_short = version_str.split(' on ')[0] if ' on ' in version_str else version_str
+                    
+                    return {
+                        "connected": True,
+                        "version": version_short,
+                        "full_version": version_str
+                    }
+        except Exception as e:
+            logger.error(f"Failed to get PostgreSQL version: {e}")
+            return {
+                "connected": False,
+                "error": str(e)
+            }
+    
     def close(self) -> None:
         """Close connection pool."""
         if self.pool:


### PR DESCRIPTION
- Add get_version_info() method to PostgreSQLManager
- Update app.py index route to use PostgreSQL version when enabled
- Status panel now correctly displays 'PostgreSQL 15.14' instead of SQLite
- Maintains backward compatibility with SQLite mode
- Follows USE_POSTGRESQL_URL_MANAGER feature flag