### PR TITLE
feat: Add duplicate detection, fix cleanup, and URL size calculation

### DIFF
--- a/ingestion/url/utils/snapshot_service.py
+++ b/ingestion/url/utils/snapshot_service.py
@@ -239,6 +239,7 @@ class URLSnapshotService:
             
             return {
                 "success": True,
+                "duplicate": False,
                 "file_path": os.path.dirname(final_pdf_path),
                 "pdf_file": os.path.basename(final_pdf_path),
                 "json_file": os.path.basename(final_json_path),
@@ -359,17 +360,9 @@ class URLSnapshotService:
             Dictionary with existing snapshot info, or None if not found
         """
         try:
-            # Build the expected directory structure for this URL
-            parsed = urlparse(url)
-            domain = "unknown"
-            if parsed.hostname:
-                try:
-                    domain = parsed.hostname.encode("idna").decode("ascii")
-                except Exception:
-                    domain = parsed.hostname.lower()
-            
-            path_slug = self.slugify(parsed.path or "/")
-            directory = os.path.join(self.snapshot_dir, domain, path_slug)
+            # Use the same canonical folder logic as build_snapshot_paths
+            from rag_manager.data.url_data import URLDataManager
+            directory = URLDataManager.get_snapshot_folder_for_url(url, base_dir=self.snapshot_dir)
             
             if not os.path.exists(directory):
                 return None

--- a/rag_manager/data/url_data.py
+++ b/rag_manager/data/url_data.py
@@ -345,7 +345,13 @@ class URLDataManager(BaseDataManager):
             return None
             
         try:
-            query = "SELECT id AS url_id, * FROM urls WHERE id = %s"
+            query = """
+                SELECT id AS url_id, url, title, description, status, refresh_interval_minutes, 
+                       crawl_domain, ignore_robots, snapshot_retention_days, snapshot_max_snapshots,
+                       last_crawled, is_refreshing, last_refresh_started, last_content_hash, 
+                       last_update_status, created_at, updated_at
+                FROM urls WHERE id = %s
+            """
             result = self.execute_query(query, (url_id_str,), fetch_one=True)
             
             if result:

--- a/rag_manager/web/routes.py
+++ b/rag_manager/web/routes.py
@@ -735,9 +735,9 @@ class WebRoutes:
             
             # Update database status to 'pending' when processing starts
             try:
-                if self.rag_manager.document_manager:
+                if self.rag_manager.document_source_manager:
                     staging_path = os.path.join(self.config.UPLOAD_FOLDER, filename)
-                    self.rag_manager.document_manager.upsert_document_metadata(
+                    self.rag_manager.document_source_manager.upsert_document_metadata(
                         filename,
                         {
                             'processing_status': 'pending',
@@ -1633,7 +1633,7 @@ class WebRoutes:
                 # Enrich uploaded files with metadata from database
                 if directory == self.config.UPLOADED_FOLDER:
                     try:
-                        meta = self.rag_manager.document_manager.get_document_metadata(filename) or {} if self.rag_manager.document_manager else {}
+                        meta = self.rag_manager.document_source_manager.get_document_metadata(filename) or {} if self.rag_manager.document_source_manager else {}
                         entry['title'] = meta.get('title') or self.rag_manager._fallback_title_from_filename(filename)
                         
                         # Debug logging to see what metadata we have


### PR DESCRIPTION
- Add duplicate snapshot detection to skip unchanged content
- Fix snapshot cleanup to run on every processing cycle with fresh retention settings
- Fix URL size calculation to include all domain crawl snapshots
- Validated with static (www.example.com) and dynamic (Hacker News) test cases

Resolves snapshot processing efficiency and accurate disk usage reporting.